### PR TITLE
Join event with geo location

### DIFF
--- a/CMPUT301F24mikasa/app/src/main/res/layout/activity_view_event.xml
+++ b/CMPUT301F24mikasa/app/src/main/res/layout/activity_view_event.xml
@@ -30,6 +30,22 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp" />
 
+    <EditText
+        android:id="@+id/editTextCity"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/enter_city"
+        android:inputType="text"
+        android:visibility="gone"/>
+
+    <EditText
+        android:id="@+id/editTextProvince"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/enter_full_province_eg_alberta"
+        android:inputType="text"
+        android:visibility="gone"/>
+
     <Button
         android:id="@+id/btnSignUp"
         android:layout_width="match_parent"

--- a/CMPUT301F24mikasa/app/src/main/res/values/strings.xml
+++ b/CMPUT301F24mikasa/app/src/main/res/values/strings.xml
@@ -93,4 +93,7 @@
 
     <string name="location">Location eg. Edmonton, Alberta (optional)</string>
 
+    <string name="enter_city">Enter City</string>
+    <string name="enter_full_province_eg_alberta">Enter full Province (eg. Alberta)</string>
+
 </resources>


### PR DESCRIPTION
Allows user to manually enter "City" and "Province" for signing up for an event requiring geo-location.
They can choose to not sign up as well of course, by going back.